### PR TITLE
Add unit tests

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,24 +3,12 @@ use reqwest::{
     Client, Error, Method, Response,
 };
 
-macro_rules! filter {
-    ( $( $op:ident ),* ) => {
-        $(
-            pub fn $op(mut self, column: &str, param: &str) -> Self {
-                self.queries.push((column.to_string(),
-                                   format!("{}.{}", stringify!($op), param)));
-                self
-            }
-        )*
-    }
-}
-
 #[derive(Default)]
 pub struct Builder {
     method: Method,
     url: String,
     schema: Option<String>,
-    queries: Vec<(String, String)>,
+    pub(crate) queries: Vec<(String, String)>,
     headers: HeaderMap,
     body: Option<String>,
     is_rpc: bool,
@@ -147,19 +135,6 @@ impl Builder {
         self.method = Method::DELETE;
         self.headers
             .append("Prefer", HeaderValue::from_static("return=representation"));
-        self
-    }
-
-    // It's unfortunate that `in` is a keyword, otherwise it'd belong in the
-    // collection of filters below
-    filter!(
-        eq, gt, gte, lt, lte, neq, like, ilike, is, fts, plfts, phfts, wfts, cs, cd, ov, sl, sr,
-        nxr, nxl, adj, not
-    );
-
-    pub fn in_(mut self, column: &str, param: &str) -> Self {
-        self.queries
-            .push((column.to_string(), format!("in.{}", param)));
         self
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -218,7 +218,7 @@ mod tests {
     fn auth_with_token() {
         let builder = Builder::new(TABLE_URL, None).auth("$Up3rS3crET");
         assert_eq!(
-            builder.headers.get("Authentication").unwrap(),
+            builder.headers.get("Authorization").unwrap(),
             HeaderValue::from_static("Bearer $Up3rS3crET")
         );
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,28 +1,290 @@
 use crate::Builder;
 
-macro_rules! filter {
-    ( $( $op:ident ),* ) => {
-        $(
-            pub fn $op(mut self, column: &str, param: &str) -> Self {
-                self.queries.push((column.to_string(),
-                                   format!("{}.{}", stringify!($op), param)));
-                self
-            }
-        )*
+impl Builder {
+    pub fn eq<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("eq.{}", param.into())));
+        self
+    }
+
+    pub fn neq<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("neq.{}", param.into())));
+        self
+    }
+
+    pub fn gt<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("gt.{}", param.into())));
+        self
+    }
+
+    pub fn gte<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("gte.{}", param.into())));
+        self
+    }
+
+    pub fn lt<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("lt.{}", param.into())));
+        self
+    }
+
+    pub fn lte<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("lte.{}", param.into())));
+        self
+    }
+
+    pub fn like<S>(mut self, column: S, param: &str) -> Self
+    where
+        S: Into<String>,
+    {
+        let param = str::replace(param, '%', "*");
+        self.queries
+            .push((column.into(), format!("like.{}", param)));
+        self
+    }
+
+    pub fn ilike<S>(mut self, column: S, param: &str) -> Self
+    where
+        S: Into<String>,
+    {
+        let param = str::replace(param, '%', "*");
+        self.queries
+            .push((column.into(), format!("ilike.{}", param)));
+        self
+    }
+
+    pub fn is<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("is.{}", param.into())));
+        self
+    }
+
+    pub fn in_<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<Vec<String>>,
+    {
+        // As per PostgREST docs, `in` should allow quoted commas
+        let param: Vec<String> = param
+            .into()
+            .iter()
+            .map(|s| {
+                if s.contains(',') {
+                    format!("\"{}\"", s)
+                } else {
+                    s.to_string()
+                }
+            })
+            .collect();
+        self.queries
+            .push((column.into(), format!("in.({})", param.join(","))));
+        self
+    }
+
+    pub fn cs<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<Vec<String>>,
+    {
+        self.queries
+            .push((column.into(), format!("cs.{{{}}}", param.into().join(","))));
+        self
+    }
+
+    pub fn cd<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<Vec<String>>,
+    {
+        self.queries
+            .push((column.into(), format!("cd.{{{}}}", param.into().join(","))));
+        self
+    }
+
+    pub fn sl<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("sl.{}", param.into())));
+        self
+    }
+
+    pub fn sr<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("sr.{}", param.into())));
+        self
+    }
+
+    pub fn nxl<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("nxl.{}", param.into())));
+        self
+    }
+
+    pub fn nxr<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("nxr.{}", param.into())));
+        self
+    }
+
+    pub fn adj<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("adj.{}", param.into())));
+        self
+    }
+
+    pub fn ov<S, T>(mut self, column: S, param: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.queries
+            .push((column.into(), format!("ov.{}", param.into())));
+        self
+    }
+
+    pub fn fts<S, T>(mut self, column: S, tsquery: T, config: Option<String>) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        let config = if let Some(conf) = config {
+            format!("({})", conf)
+        } else {
+            String::new()
+        };
+        self.queries
+            .push((column.into(), format!("fts{}.{}", config, tsquery.into())));
+        self
+    }
+
+    pub fn plfts<S, T>(mut self, column: S, tsquery: T, config: Option<String>) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        let config = if let Some(conf) = config {
+            format!("({})", conf)
+        } else {
+            String::new()
+        };
+        self.queries
+            .push((column.into(), format!("plfts{}.{}", config, tsquery.into())));
+        self
+    }
+
+    pub fn phfts<S, T>(mut self, column: S, tsquery: T, config: Option<String>) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        let config = if let Some(conf) = config {
+            format!("({})", conf)
+        } else {
+            String::new()
+        };
+        self.queries
+            .push((column.into(), format!("phfts{}.{}", config, tsquery.into())));
+        self
+    }
+
+    pub fn wfts<S, T>(mut self, column: S, tsquery: T, config: Option<String>) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        let config = if let Some(conf) = config {
+            format!("({})", conf)
+        } else {
+            String::new()
+        };
+        self.queries
+            .push((column.into(), format!("wfts{}.{}", config, tsquery.into())));
+        self
     }
 }
 
-impl Builder {
-    // It's unfortunate that `in` is a keyword, otherwise it'd belong in the
-    // collection of filters below
-    filter!(
-        eq, gt, gte, lt, lte, neq, like, ilike, is, fts, plfts, phfts, wfts, cs, cd, ov, sl, sr,
-        nxr, nxl, adj, not
-    );
+#[cfg(test)]
+mod tests {
+    use crate::Postgrest;
 
-    pub fn in_(mut self, column: &str, param: &str) -> Self {
-        self.queries
-            .push((column.to_string(), format!("in.{}", param)));
-        self
+    const REST_URL: &str = "http://localhost:3000";
+
+    #[test]
+    fn simple_filters_assert_query() {
+        let client = Postgrest::new(REST_URL);
+
+        let req = client.from("users").select("ignored").eq("column", "key");
+        assert_eq!(
+            req.queries
+                .contains(&("column".to_string(), "eq.key".to_string())),
+            true
+        );
+
+        let req = client.from("users").select("ignored").neq("column", "key");
+        assert_eq!(
+            req.queries
+                .contains(&("column".to_string(), "neq.key".to_string())),
+            true
+        );
+
+        let req = client.from("users").select("ignored").gt("column", "key");
+        assert_eq!(
+            req.queries
+                .contains(&("column".to_string(), "gt.key".to_string())),
+            true
+        );
+
+        // ...
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,28 @@
+use crate::Builder;
+
+macro_rules! filter {
+    ( $( $op:ident ),* ) => {
+        $(
+            pub fn $op(mut self, column: &str, param: &str) -> Self {
+                self.queries.push((column.to_string(),
+                                   format!("{}.{}", stringify!($op), param)));
+                self
+            }
+        )*
+    }
+}
+
+impl Builder {
+    // It's unfortunate that `in` is a keyword, otherwise it'd belong in the
+    // collection of filters below
+    filter!(
+        eq, gt, gte, lt, lte, neq, like, ilike, is, fts, plfts, phfts, wfts, cs, cd, ov, sl, sr,
+        nxr, nxl, adj, not
+    );
+
+    pub fn in_(mut self, column: &str, param: &str) -> Self {
+        self.queries
+            .push((column.to_string(), format!("in.{}", param)));
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,26 +9,39 @@ pub struct Postgrest {
 }
 
 impl Postgrest {
-    pub fn new(url: &str) -> Self {
+    pub fn new<T>(url: T) -> Self
+    where
+        T: Into<String>,
+    {
         Postgrest {
-            url: url.to_string(),
+            url: url.into(),
             schema: None,
         }
     }
 
-    pub fn schema(mut self, schema: &str) -> Self {
-        self.schema = Some(schema.to_string());
+    pub fn schema<T>(mut self, schema: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.schema = Some(schema.into());
         self
     }
 
-    pub fn from(&self, table: &str) -> Builder {
-        let url = format!("{}/{}", self.url, table);
-        Builder::new(&url, self.schema.clone())
+    pub fn from<T>(&self, table: T) -> Builder
+    where
+        T: Into<String>,
+    {
+        let url = format!("{}/{}", self.url, table.into());
+        Builder::new(url, self.schema.clone())
     }
 
-    pub fn rpc(&self, function: &str, params: &str) -> Builder {
-        let url = format!("{}/rpc/{}", self.url, function);
-        Builder::new(&url, self.schema.clone()).rpc(params)
+    pub fn rpc<T, U>(&self, function: T, params: U) -> Builder
+    where
+        T: Into<String>,
+        U: Into<String>,
+    {
+        let url = format!("{}/rpc/{}", self.url, function.into());
+        Builder::new(url, self.schema.clone()).rpc(params)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod filter;
 
 use builder::Builder;
 


### PR DESCRIPTION
Add unit tests for Postgrest and Builder.

Some unit tests for filtering are still left out. Will look into implementing those as [doctests](https://doc.rust-lang.org/rustdoc/documentation-tests.html) instead, in the spirit of [doctest-js](https://github.com/supabase/doctest-js).

Also refactored filtering functions out of Builder.

Also also changed most &str arguments to Into<String> (easier for users to pass). (Should've separated these into their own PR, but oh well)