### PR TITLE
Supabase auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,26 @@ Simple example:
 ```rust
 use postgrest::Postgrest;
 
-let client = Postgrest::new("https://your.postgrest.endpoint");
+let client = Postgrest::new("https://your.postgrest.endpoint")
+    .auth("YOUR_POSTGREST_JWT");
 let resp = client
     .from("your_table")
+    .select("*")
+    .execute()
+    .await?;
+let body = resp
+    .text()
+    .await?;
+```
+
+Example using SupaBase API key but no user JWT:
+```rust
+use postgrest::Postgrest;
+
+let client = Postgrest::new("https://your-supabase.endpoint/rest/v1/")
+    .supa_auth("YOUR_SUPABASE_PUBLIC_API_KEY", None);
+let resp = client
+    .from("YOUR_TABLE")
     .select("*")
     .execute()
     .await?;


### PR DESCRIPTION
## What kind of change does this PR introduce?

SupaBase specific feature addition and documentation update.

## What is the current behavior?

Only works with the PostgRest JWT only auth scheme.  

## What is the new behavior?

This addition adds support for the Kong gateway API key in SupaBase as an alternate authorization trait (supa_auth()). Documentation also captures the API path needed.

## Additional context
New doc and unit tests added.  All tests passing locally.
