### PR TITLE
feat: Add support for serde behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,13 @@ edition = "2021"
 
 [dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+serde_json = { version = "1.0.128", optional = true }
+serde = { version = "1.0.210", optional = true }
 
 [dev-dependencies]
 json = "0.12"
 tokio = { version = "1", features = ["full"] }
+serde = { version = "1.0.210", features = ["derive"] }
+
+[features]
+serde = ["dep:serde_json", "dep:serde"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -796,6 +796,19 @@ mod tests {
             HeaderValue::from_static("return=representation,resolution=merge-duplicates")
         );
     }
+    
+    #[test]
+    #[cfg(feature = "serde")]
+    fn upsert_assert_prefer_header_serde() {
+        let client = Client::new();
+        let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), client)
+            .upsert(&())
+            .unwrap();
+        assert_eq!(
+            builder.headers.get("Prefer").unwrap(),
+            HeaderValue::from_static("return=representation,resolution=merge-duplicates")
+        );
+    }
 
     #[test]
     fn not_rpc_should_not_have_flag() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -442,7 +442,7 @@ impl Builder {
     /// let client = Postgrest::new("https://your.postgrest.endpoint");
     /// client
     ///     .from("users")
-    ///     .insert(&my_serializable_struct)?;
+    ///     .insert(&my_serializable_struct).unwrap();
     /// ```
     #[cfg(feature = "serde")]
     pub fn insert<T>(self, body: &T) -> serde_json::Result<Self>
@@ -506,7 +506,7 @@ impl Builder {
     /// let client = Postgrest::new("https://your.postgrest.endpoint");
     /// client
     ///     .from("users")
-    ///     .upsert(&my_serializable_struct)?;
+    ///     .upsert(&my_serializable_struct).unwrap();
     /// ```
     #[cfg(feature = "serde")]
     pub fn upsert<T>(self, body: &T) -> serde_json::Result<Self>
@@ -543,11 +543,23 @@ impl Builder {
     /// let client = Postgrest::new("https://your.postgrest.endpoint");
     /// // Suppose `users` are keyed an SERIAL primary key,
     /// // but have a unique index on `username`.
-    /// client
-    ///     .from("users")
-    ///     .upsert(r#"[{ "username": "soedirgo", "status": "online" },
-    ///                 { "username": "jose", "status": "offline" }]"#)
-    ///     .on_conflict("username");
+    #[cfg_attr(not(feature = "serde"), doc = r##"
+     client
+         .from("users")
+         .upsert(r#"[{ "username": "soedirgo", "status": "online" },
+                     { "username": "jose", "status": "offline" }]"#)
+         .on_conflict("username");
+    "##)]
+    #[cfg_attr(feature = "serde", doc = r##"
+     #[derive(serde::Serialize)]
+     struct MyStruct {}
+    
+     let my_serializable_struct = MyStruct {};
+    
+     client
+         .from("users")
+         .upsert(&my_serializable_struct).unwrap();
+    "##)]
     /// ```
     pub fn on_conflict<T>(mut self, columns: T) -> Self
     where
@@ -595,7 +607,7 @@ impl Builder {
     /// client
     ///     .from("users")
     ///     .eq("username", "soedirgo")
-    ///     .update(&my_serializable_struct)?;
+    ///     .update(&my_serializable_struct).unwrap();
     /// ```
     #[cfg(feature = "serde")]
     pub fn update<T>(self, body: &T) -> serde_json::Result<Self>

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -787,6 +787,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "serde"))]
     fn upsert_assert_prefer_header() {
         let client = Client::new();
         let builder = Builder::new(TABLE_URL, None, HeaderMap::new(), client).upsert("ignored");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //! Updating a table:
 //! ```
 //! # use postgrest::Postgrest;
+//! # #[cfg(not(feature = "serde"))]
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! # let client = Postgrest::new("https://your.postgrest.endpoint");
 //! let resp = client

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -75,6 +75,7 @@ async fn relational_join() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn insert() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL);
     let resp = client
@@ -90,6 +91,7 @@ async fn insert() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn upsert() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL);
     let resp = client
@@ -110,6 +112,7 @@ async fn upsert() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn upsert_existing() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL);
     let resp = client
@@ -128,6 +131,7 @@ async fn upsert_existing() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn upsert_nonexisting() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL);
     let resp = client
@@ -145,6 +149,7 @@ async fn upsert_nonexisting() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn update() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL);
     let resp = client

--- a/tests/multi_schema.rs
+++ b/tests/multi_schema.rs
@@ -37,6 +37,7 @@ async fn read_other_schema() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn write_other_schema() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL);
     let resp = client
@@ -81,6 +82,7 @@ async fn read_nonexisting_schema() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+#[cfg(not(feature = "serde"))]
 async fn write_nonexisting_schema() -> Result<(), Box<dyn Error>> {
     let client = Postgrest::new(REST_URL).schema("private");
     let resp = client


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add support for serde behind feature flag for `insert`, `upsert` and `update`
Might fix #35 

## What is the current behavior?

Library only supports body where type is `Into<String>`

## What is the new behavior?

When enabling the feature flag "`serde`", the body parameter for the mentioned functions should now be `serde::Serialize`

## Additional comments
I have tried to make the serde functionality "opt-in", which should mean that by default we keep the old functionality.